### PR TITLE
Add libarchive yum package for rhel

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -81,6 +81,7 @@ case $DISTRO in
 			gcc \
 			gcc-c++ \
 			git \
+			libarchive \
 			libcurl-devel \
 			libicu-devel \
 			libjpeg-turbo-devel \


### PR DESCRIPTION
I googled where the test failed in the GitHib Actions CI and found information that it was resolved by adding the `libarchive` yum package, so I fixed it and the GitHib Actions CI passed. I did.

Please confirm it.

Refs: https://github.com/ComplianceAsCode/content/issues/7016#issuecomment-845066366